### PR TITLE
porting to Qt6 [rm#75257]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
 cmake_minimum_required(VERSION 3.19)
-project(BAST)
+project(BAST LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,7 +42,19 @@ set(BAST_SOURCES
     predWriter.cpp
 )
 
-find_package(Qt5 REQUIRED COMPONENTS Core Xml)
+find_package(Qt6 COMPONENTS Core Xml)
+if(Qt6_FOUND)
+    message(STATUS "Using Qt6")
+    set(QT_VERSION 6)
+else()
+    find_package(Qt5 COMPONENTS Core Xml REQUIRED)
+    if(Qt5_FOUND)
+        message(STATUS "Using Qt5")
+        set(QT_VERSION 5)
+    else()
+        message(FATAL_ERROR "Neither Qt5 nor Qt6 found")
+    endif()
+endif()
 
 include_directories(
         ${CMAKE_CURRENT_BINARY_DIR}
@@ -50,7 +62,14 @@ include_directories(
 )
 
 add_library(BAST_LIB STATIC ${BAST_SOURCES} ${BAST_HEADERS})
-target_link_libraries(BAST_LIB PRIVATE Qt5::Core Qt5::Xml)
 
-target_compile_features(BAST_LIB PUBLIC cxx_std_20)
+# Set up the executable
+if(QT_VERSION EQUAL 6)
+    target_link_libraries(BAST_LIB PRIVATE Qt6::Core Qt6::Xml)
+elseif(QT_VERSION EQUAL 5)
+    target_link_libraries(BAST_LIB PRIVATE Qt5::Core Qt5::Xml)
+endif()
+
+
+target_compile_features(BAST_LIB PUBLIC cxx_std_17)
 set_target_properties(BAST_LIB PROPERTIES PREFIX "lib" OUTPUT_NAME "BAST")


### PR DESCRIPTION
Build against Qt6, when available, otherwise Qt5.
Compiles with gcc-10.2.1, gcc-13.2.0, AppleClang 15.0.0.15000309, AppleClang 16.0.0.16000026