### PR TITLE
Handle unused local variables [#80199]

### DIFF
--- a/src/substReader.cpp
+++ b/src/substReader.cpp
@@ -206,8 +206,8 @@ Subst readSubstitution(const tinyxml2::XMLElement *dom,
         throw SubstReaderException(
             "Missing child 'Variables' in 'ANY_Sub' element.");
       std::vector<TypedVar> vec;
-      for (const tinyxml2::XMLElement *ce = vars->FirstChildElement();
-           ce != nullptr; ce = ce->NextSiblingElement()) {
+      for (const tinyxml2::XMLElement *ce = vars->FirstChildElement("Id");
+           ce != nullptr; ce = ce->NextSiblingElement("Id")) {
         vec.push_back(VarNameFromId(ce, typeInfos));
       }
       const tinyxml2::XMLElement *pred = dom->FirstChildElement("Pred");


### PR DESCRIPTION
B type checking may accept unused local variables in implementations. The ibxml/poxml stages use the Unused_Id name for the corresponding XML elements. BAST is updated to ignore such elements when reading XML input.